### PR TITLE
 feat: allow custom css classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # vue-form-json
 
-[![Edit vue-form-json-demo](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/qzk9431256?autoresize=1&hidenavigation=1&module=%2Fsrc%2FApp.vue&view=preview)
+[![Edit vue-form-json-demo](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/74omp7n1mx?autoresize=1&hidenavigation=1&module=%2Fsrc%2FApp.vue&view=preview)
 
 ## Generate a responsive vue form with validation and bulma style, from [json](https://github.com/14nrv/vue-form-json/blob/master/src/components/Form/fields.json)
 All fields are required and input text by default.

--- a/src/App.vue
+++ b/src/App.vue
@@ -34,4 +34,7 @@ export default {
 <style lang="stylus">
   @require '../node_modules/bulma/css/bulma.min.css'
   @require '../node_modules/@fortawesome/fontawesome-free/css/all.min.css'
+
+  .labelDefaultMb
+    margin-bottom .5rem
 </style>

--- a/src/components/Form/Form.spec.js
+++ b/src/components/Form/Form.spec.js
@@ -194,6 +194,68 @@ describe('Form', () => {
     b.domHasNot($errorMessage)
   })
 
+  describe('custom css class', () => {
+    it('apply custom classes', () => {
+      const customClassInJson = flatten(fields).find(x => Object.keys(x).includes('parentClass')).parentClass
+      const allCustomClass = wrapper.findAll(`.field.${customClassInJson.split(' ').join('.')}`)
+
+      expect(allCustomClass).toHaveLength(1)
+    })
+
+    it('add customs class in json array', async () => {
+      const Y_CLASS_NAME = 'yClass'
+      const Z_CLASS_NAME = 'zClass'
+
+      wrapper.setProps({
+        formFields: [
+          [
+            { label: 'x' },
+            { label: 'y', parentClass: Y_CLASS_NAME },
+            { label: 'z', parentClass: Z_CLASS_NAME }
+          ]
+        ]
+      })
+      await wrapper.vm.$nextTick()
+
+      b.domHas(`.field.${Y_CLASS_NAME}`)
+      b.domHas(`.field.${Z_CLASS_NAME}`)
+
+      const allY = wrapper.findAll(`.${Y_CLASS_NAME}`)
+      expect(allY).toHaveLength(1)
+
+      const allZ = wrapper.findAll(`.${Z_CLASS_NAME}`)
+      expect(allZ).toHaveLength(1)
+    })
+
+    it('add custom class with classic json', async () => {
+      const LABEL_CLASS = 'labelClass'
+
+      wrapper.setProps({ formFields: [{ label: 'label', parentClass: LABEL_CLASS }] })
+      await wrapper.vm.$nextTick()
+
+      b.domHas(`.field.${LABEL_CLASS}`)
+    })
+
+    it('add custom class with json slot', async () => {
+      const SLOT_CLASS = 'slotClass'
+
+      wrapper.setProps({ formFields: [{ slot: 'slotName', parentClass: SLOT_CLASS }] })
+      await wrapper.vm.$nextTick()
+
+      b.domHas(`.field.${SLOT_CLASS}`)
+    })
+
+    it('add custom class with json html content', async () => {
+      const HTML_CLASS = 'htmlClass'
+      const CONTENT_CLASS = 'custom-content'
+
+      wrapper.setProps({ formFields: [{ html: `<p class=${CONTENT_CLASS}>content</p>`, parentClass: HTML_CLASS }] })
+      await wrapper.vm.$nextTick()
+
+      b.domHas(`.field.${HTML_CLASS} > .${CONTENT_CLASS}`)
+    })
+  })
+
   describe('slot', () => {
     const slotContainer = '[data-test=slot]'
 

--- a/src/components/Form/Form.vue
+++ b/src/components/Form/Form.vue
@@ -4,19 +4,21 @@
 
     div(v-for="(item, index) in formFields", :key="index")
       .field-body(v-if="Array.isArray(item)")
-        .field(v-for="x in item", :key="x.label")
+        .field(v-for="x in item", :key="x.label", :class="x.parentClass")
           app-label(:item="x")
           app-control(:item="x", ref="control")
 
-      .field(v-else-if="Object.keys(item) == 'html'",
+      .field(v-else-if="Object.keys(item).includes('html')",
             v-html="Object.values(item)[0]",
+            :class="item.parentClass",
             data-test="htmlContentFromFormFields")
 
-      .field(v-else-if="Object.keys(item) == 'slot'",
+      .field(v-else-if="Object.keys(item).includes('slot')",
+            :class="item.parentClass",
             data-test="slot")
         slot(:name="Object.values(item)[0]")
 
-      .field(v-else)
+      .field(v-else, :class="item.parentClass")
         app-label(:item="item")
         app-control(:item="item", ref="control")
 

--- a/src/components/Form/fields.json
+++ b/src/components/Form/fields.json
@@ -76,6 +76,24 @@
     }
   ],
   {
+    "html": "<p class='label'>Custom css classes</p>",
+    "parentClass": "labelDefaultMb has-text-centered"
+  },
+  [
+    {
+      "label": "small",
+      "placeholder": "small",
+      "showLabel": false,
+      "isRequired": false
+    },
+    {
+      "label": "big",
+      "placeholder": "big",
+      "showLabel": false,
+      "isRequired": false
+    }
+  ],
+  {
     "label": "Message",
     "type": "textarea",
     "isRequired": false


### PR DESCRIPTION
`{ label: 'custom-label', parentClass: 'classOne classTwo' }`
Will return: .field.classOne.classTwo > .control >  input#custom-label