### PR TITLE
Support slot props

### DIFF
--- a/src/components/Form/Form.vue
+++ b/src/components/Form/Form.vue
@@ -20,7 +20,7 @@
         .field(v-else-if="Object.keys(item).includes('slot')",
               v-bind="item.attr",
               data-test="slot")
-          slot(:name="Object.values(item)[0]", v-bind="item.props")
+          slot(:name="item['slot']", v-bind="item.props")
 
         .field(v-else, v-bind="item.field && item.field.attr")
           app-label(:item="item")

--- a/src/components/Form/Form.vue
+++ b/src/components/Form/Form.vue
@@ -119,11 +119,33 @@ export default {
   }),
   created () {
     this.formValues = pipe(flatten, map(getNameOrLabel), valueToProp)(this.formFields)
+    this.addUpdateValueCallback()
   },
   mounted () {
     this.allControls = this.$refs.control
   },
+  watch: {
+    formFields: {
+      deep: true,
+      handler () {
+        this.addUpdateValueCallback()
+      }
+    }
+  },
   methods: {
+    addUpdateValueCallback () {
+      for (const field of this.formFields) {
+        if (field.slot) {
+          field.props = field.props || {}
+          field.props.updateValue = (value) => {
+            field.props.value = value
+            const nameOrLabel = getNameOrLabel(field.props)
+            if (nameOrLabel) this.formValues[nameOrLabel] = value
+          }
+          if (field.props.value) { field.props.updateValue(field.props.value) }
+        }
+      }
+    },
     async onSubmit (ev) {
       const isValidated = await this.$refs.form.validate()
 

--- a/src/components/Form/Form.vue
+++ b/src/components/Form/Form.vue
@@ -20,7 +20,7 @@
         .field(v-else-if="Object.keys(item).includes('slot')",
               v-bind="item.attr",
               data-test="slot")
-          slot(:name="Object.values(item)[0]")
+          slot(:name="Object.values(item)[0]", v-bind="item.props")
 
         .field(v-else, v-bind="item.field && item.field.attr")
           app-label(:item="item")


### PR DESCRIPTION
Current vue-form-json doesn't allow passing custom properties to the named scope, this PR enables passing arbitrary properties to the slot. A callback function `updateValue` will be injected after initialisation, so you can call it to update the value of the field.

The following example shows how one can support [tagInput in buefy](https://buefy.org/documentation/taginput/):
```html
<form-json
      :btnReset="{value: 'Reset'}"
      :btnSubmit="{value: 'Submit'}"
      :formFields="jsonFields"
      formName="tagInputDemo">
        <template slot="tagInput" slot-scope="slotProps">
          <b-taginput
                v-model="slotProps.tags"
                :data="slotProps.options"
                autocomplete
                @input="slotProps.updateValue(slotProps.tags)"
                icon="label"
                placeholder="Add a tag">
                <template #empty>
                    There are no items
                </template>
            </b-taginput>
        </template>
</form-json>
```

```js
const formFields = [
  {
    "slot": "tagInput",
    "props": {
      "label": "book tags", "options": ["drama", "sci-fi"]
    }
  }
]
```